### PR TITLE
Allow bitbucket integration to be disabled.

### DIFF
--- a/config/issues.php
+++ b/config/issues.php
@@ -3,11 +3,11 @@
 return [
     "driver" => "bitbucket",
     "credentials" => [
-        "driver"        => 'basic', //basic, oauth
-        "key"           => env("BITBUCKET_KEY"),        //oauth
-        "secret"        => env("BITBUCKET_SECRET"),     //oauth
-        "user"          => env("BITBUCKET_USER"),       //basic auth
-        "password"      => env("BITBUCKET_PASSWORD")    //basic auth
+        "driver"        => env("BITBUCKET_DRIVER", 'basic'), //basic, oauth
+        "key"           => env("BITBUCKET_KEY"),           //oauth
+        "secret"        => env("BITBUCKET_SECRET"),        //oauth
+        "user"          => env("BITBUCKET_USER"),          //basic auth
+        "password"      => env("BITBUCKET_PASSWORD")       //basic auth
     ],
     "repositories" => [
         "Xef Back"    => "revo-pos/revo-back",

--- a/tests/Unit/Integrations/BitbucketTest.php
+++ b/tests/Unit/Integrations/BitbucketTest.php
@@ -6,11 +6,18 @@ use App\Services\Bitbucket\Bitbucket;
 use Tests\TestCase;
 
 /** @group integrations */
-class BitbucketTest extends TestCase{
+class BitbucketTest extends TestCase
+{
     /** @test */
-    public function can_create_issue(){
-        $repo = "revo-pos/revo-back";
-        $issue = (new Bitbucket)->createIssue($repo, "test issue", "this is a test issue");
-        $this->assertTrue( is_numeric($issue->local_id) );
+    public function can_create_issue()
+    {
+        $driver = config('issue.credentials.driver');
+        if (! $driver) {
+            $this->markTestSkipped('Bitbucket not configured');
+        }
+
+        $repo = 'revo-pos/revo-back';
+        $issue = (new Bitbucket)->createIssue($repo, 'test issue', 'this is a test issue');
+        $this->assertTrue(is_numeric($issue->local_id));
     }
 }


### PR DESCRIPTION
When running the tests locally, bitbucket integration fails for lack of integration settings. Suppose not everyone uses that integration, it could be nice to set the test as skipped instead of brutally failing.