### PR TITLE
Add error when user tries to change password but fails validation

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -25,6 +25,10 @@ class AppServiceProvider extends ServiceProvider
         Validator::extend('old_password', function ($attribute, $value, $parameters, $validator) {
             return Hash::check($value, current($parameters));
         });
+
+        Validator::replacer('old_password', function ($message, $attribute, $rule, $parameters) {
+            return __('passwords.change_error');
+        });
     }
 
     /**

--- a/resources/lang/en/passwords.php
+++ b/resources/lang/en/passwords.php
@@ -17,7 +17,7 @@ return [
     'reset'         => 'Your password has been reset!',
     'sent'          => 'We have e-mailed your password reset link!',
     'token'         => 'This password reset token is invalid.',
-    'user'          => "We can't find a user with that e-mail address.",
-    'change_error'  => "The password you entered did not match your current password."
+    'user'          => 'We can't find a user with that e-mail address.',
+    'change_error'  => 'The password you entered did not match your current password.',
 
 ];

--- a/resources/lang/en/passwords.php
+++ b/resources/lang/en/passwords.php
@@ -17,7 +17,7 @@ return [
     'reset'         => 'Your password has been reset!',
     'sent'          => 'We have e-mailed your password reset link!',
     'token'         => 'This password reset token is invalid.',
-    'user'          => 'We can't find a user with that e-mail address.',
+    'user'          => 'We can\'t find a user with that e-mail address.',
     'change_error'  => 'The password you entered did not match your current password.',
 
 ];

--- a/resources/lang/en/passwords.php
+++ b/resources/lang/en/passwords.php
@@ -18,5 +18,6 @@ return [
     'sent'     => 'We have e-mailed your password reset link!',
     'token'    => 'This password reset token is invalid.',
     'user'     => "We can't find a user with that e-mail address.",
+    'change_error'   => "The password you entered did not match your current password."
 
 ];

--- a/resources/lang/en/passwords.php
+++ b/resources/lang/en/passwords.php
@@ -13,11 +13,11 @@ return [
     |
     */
 
-    'password' => 'Passwords must be at least six characters and match the confirmation.',
-    'reset'    => 'Your password has been reset!',
-    'sent'     => 'We have e-mailed your password reset link!',
-    'token'    => 'This password reset token is invalid.',
-    'user'     => "We can't find a user with that e-mail address.",
-    'change_error'   => "The password you entered did not match your current password."
+    'password'      => 'Passwords must be at least six characters and match the confirmation.',
+    'reset'         => 'Your password has been reset!',
+    'sent'          => 'We have e-mailed your password reset link!',
+    'token'         => 'This password reset token is invalid.',
+    'user'          => "We can't find a user with that e-mail address.",
+    'change_error'  => "The password you entered did not match your current password."
 
 ];


### PR DESCRIPTION
Provides a localised error (only added English error) when a user tries to change their password but enters the incorrect current password