### PR TITLE
Fixed missing SSL parameter in Mailbox class.

### DIFF
--- a/app/Services/Pop3/Mailbox.php
+++ b/app/Services/Pop3/Mailbox.php
@@ -9,7 +9,7 @@ class Mailbox
 
     public function login($host, $port, $user, $pass, $folder = 'INBOX', $ssl = false, $options = null)
     {
-        $ssl           = ($ssl == false) ? '/novalidate-cert' : '';
+        $ssl           = ($ssl == false) ? '/novalidate-cert' : '/ssl';
         $options       = $options ?: '/pop3';
         $this->mailbox = new \PhpImap\Mailbox('{'."$host:$port$options$ssl"."}$folder", $user, $pass, storage_path('app/mail_attachments'));
 


### PR DESCRIPTION
If we want to use SSL, we should pass '/ssl' to the imapPath, not '' (blank). 