### PR TITLE
Fixes issue where logo in email would not load

### DIFF
--- a/resources/views/emails/layout.blade.php
+++ b/resources/views/emails/layout.blade.php
@@ -15,7 +15,7 @@
     @yield('body')
 
     <div style="margin-top:40px">
-        Powered by <a href="https://github.com/BadChoice/handesk"><img src="http://handesk.dev/images/handesk_full.png" height="30" align="center"></a>
+        Powered by <a href="https://github.com/BadChoice/handesk"><img src="{{ url('/images/handesk_full.png') }}" height="30" align="center"></a>
     </div>
 
 </body>


### PR DESCRIPTION
The logo in the email is located at handesk.dev which does not work. This points it at the installed application's domain.

This then has to be set to the desired URL/domain
`"APP_URL=http://localhost"`