### PR TITLE
Added user signature to textbox by default

### DIFF
--- a/app/Ticket.php
+++ b/app/Ticket.php
@@ -155,8 +155,8 @@ class Ticket extends BaseModel
         }
         $previousStatus = $this->updateStatusFromComment($user, $newStatus);
         $this->associateUserIfNecessary($user);
-        if (! $body) {
-            return;
+        if (! $body or $body === $user->settings->tickets_signature) {
+            return null;
         }
 
         $comment = $this->comments()->create([

--- a/resources/views/tickets/show.blade.php
+++ b/resources/views/tickets/show.blade.php
@@ -36,7 +36,7 @@
         @include('components.assignActions', ["endpoint" => "tickets", "object" => $ticket])
         <div class="comment new-comment">
             {{ Form::open(["url" => route("comments.store", $ticket) , "files" => true, "id" => "comment-form"]) }}
-            <textarea id="comment-text-area" name="body"></textarea>
+            <textarea id="comment-text-area" name="body">@if(auth()->user()->settings->tickets_signature)&#13;&#13;{{ auth()->user()->settings->tickets_signature }}@endif</textarea>
             @include('components.uploadAttachment', ["attachable" => $ticket, "type" => "tickets"])
             {{ Form::hidden('new_status', $ticket->status, ["id" => "new_status"]) }}
             @if($ticket->isEscalated() )


### PR DESCRIPTION
Adds the user signature (if any) to the textarea in the ticket with two newlines above.
I would argue that this is a better approach than assigning it to the end of the text after submitted, this way you can remove / edit it without anything special features, a well used system for helpdesks.

closes #4 