### PR TITLE
Cutting down Title Length

### DIFF
--- a/app/Ticket.php
+++ b/app/Ticket.php
@@ -36,7 +36,7 @@ class Ticket extends BaseModel
     {
         $requester = Requester::findOrCreate($requester['name'] ?? 'Unknown', $requester['email'] ?? null);
         $ticket    = $requester->tickets()->create([
-            'title'        => $title,
+            'title'        => substr($title, 0, 190),
             'body'         => $body,
             'public_token' => str_random(24),
         ])->attachTags($tags);


### PR DESCRIPTION
I got an error while creating a ticket, this might help. The max title length in the database is set to 191, if you try to put in a string longer than that the application just drops the email and no further emails seem to be processed. huge bug.