### PR TITLE
MAJOR issue. Probably fixes #125, #154

### DIFF
--- a/app/Notifications/TicketCreated.php
+++ b/app/Notifications/TicketCreated.php
@@ -27,7 +27,7 @@ class TicketCreated extends Notification implements ShouldQueue
      */
     public function via($notifiable)
     {
-        if (isset($notifiable->settings) && $notifiable->settings->ticket_created_notification == false) {
+        if (isset($notifiable->settings) && $notifiable->settings->new_ticket_notification == false) {
             return [];
         }
 


### PR DESCRIPTION
I just noticed that Admin.php checks in line 30 for:

`$notifiable->settings->ticket_created_notification` while there is no `ticket_created_notification` option in the settings. Maybe this is legacy code from your installation?

The Setting in both the php form as well as the settings table is `new_ticket_notification`.

Probably closes both #125 as well as #154 