### PR TITLE
fix: wrong used migration

### DIFF
--- a/database/migrations/2018_11_11_112155_add_rating_to_tickets.php
+++ b/database/migrations/2018_11_11_112155_add_rating_to_tickets.php
@@ -17,7 +17,7 @@ class AddRatingToTickets extends Migration
             $table->tinyInteger('rating')->after('level')->nullable();
         });
 
-        Schema::create('user_settings', function (Blueprint $table) {
+        Schema::table('user_settings', function (Blueprint $table) {
             $table
                 ->boolean('ticket_rated_notification')
                 ->after('mention_notification')
@@ -36,7 +36,7 @@ class AddRatingToTickets extends Migration
             $table->dropColumn('rating');
         });
 
-        Schema::create('user_settings', function (Blueprint $table) {
+        Schema::table('user_settings', function (Blueprint $table) {
             $table->dropColumn('ticket_rated_notification');
         });
     }


### PR DESCRIPTION
When i run the migration i get error. Because user_settings table already exists. so "create" method should change with "table".