### PR TITLE
Slack invitation link not working

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -122,7 +122,6 @@ There is the `badchoice/handesk-php` package in packagist to easily talk with th
 
 ## Community
 We have a slack channel at [https://handesk.slack.com/](https://handesk.slack.com)
-And you can join with the following [invitation](https://handesk.slack.com/shared_invite/enQtMzQwMTg5ODkwNDUxLWVhYjFkNzNkMmE2NWUxYjcwZTNhMmM0M2M3NmVkMzdhNWI0NTU0ZGM0ODFlNTVlMGZhMTA0YzM0YjA3NjcxMTc)
 
 Join in with the following link
 


### PR DESCRIPTION
the first link is not working, please remove it. :-)