### PR TITLE
Escaping script tag on create and comment ticket.

### DIFF
--- a/app/Http/Controllers/Api/CommentsController.php
+++ b/app/Http/Controllers/Api/CommentsController.php
@@ -9,7 +9,7 @@ class CommentsController extends ApiController
 {
     public function store(Ticket $ticket)
     {
-        $comment = $ticket->addComment(null, sanitizeJSInjection(request('body')), request('new_status'));
+    	$comment = $ticket->addComment(null, strip_tags(request('body')), request('new_status'));
         if (! $comment) {
             return $this->respond(['id' => null, 'message' => 'Can not create a comment with empty body'], Response::HTTP_OK);
         }

--- a/app/Http/Controllers/Api/CommentsController.php
+++ b/app/Http/Controllers/Api/CommentsController.php
@@ -9,7 +9,7 @@ class CommentsController extends ApiController
 {
     public function store(Ticket $ticket)
     {
-        $comment = $ticket->addComment(null, request('body'), request('new_status'));
+        $comment = $ticket->addComment(null, sanitizeJSInjection(request('body')), request('new_status'));
         if (! $comment) {
             return $this->respond(['id' => null, 'message' => 'Can not create a comment with empty body'], Response::HTTP_OK);
         }

--- a/app/Http/Controllers/Api/TicketsController.php
+++ b/app/Http/Controllers/Api/TicketsController.php
@@ -38,8 +38,8 @@ class TicketsController extends ApiController
 
         $ticket = Ticket::createAndNotify(
             request('requester'),
-            sanitizeJSInjection(request('title')),
-            sanitizeJSInjection(request('body')),
+            strip_tags(request('title')),
+            strip_tags(request('body')),
             request('tags')
         );
 

--- a/app/Http/Controllers/Api/TicketsController.php
+++ b/app/Http/Controllers/Api/TicketsController.php
@@ -38,8 +38,8 @@ class TicketsController extends ApiController
 
         $ticket = Ticket::createAndNotify(
             request('requester'),
-            request('title'),
-            request('body'),
+            sanitizeJSInjection(request('title')),
+            sanitizeJSInjection(request('body')),
             request('tags')
         );
 

--- a/helpers/helpers.php
+++ b/helpers/helpers.php
@@ -55,3 +55,8 @@ function toPercentage($value, $inverse = false)
 {
     return  ($inverse ? 1 - $value : $value) * 100;
 }
+
+function sanitizeJSInjection($text)
+{
+    return str_replace('/script>', '/\script>', str_replace('<script', '<\script', $text));
+}

--- a/helpers/helpers.php
+++ b/helpers/helpers.php
@@ -55,8 +55,3 @@ function toPercentage($value, $inverse = false)
 {
     return  ($inverse ? 1 - $value : $value) * 100;
 }
-
-function sanitizeJSInjection($text)
-{
-    return str_replace('/script>', '/\script>', str_replace('<script', '<\script', $text));
-}

--- a/tests/Feature/Api/SimpleTicketTest.php
+++ b/tests/Feature/Api/SimpleTicketTest.php
@@ -92,7 +92,7 @@ class SimpleTicketTest extends TestCase
                 "name"  => "johndoe",
                 "email" => "john@doe.com"
             ],
-            "title"         => "App <script>is not working</script>",
+            "title"         => "App <script>is not working</script> >>>",
             "body"          => "I can't log in into the application<script>alert(1)</script>",
             "tags"          => ["xef"]
         ],["token" => 'the-api-token']);
@@ -106,8 +106,8 @@ class SimpleTicketTest extends TestCase
                 $this->assertEquals($requester->email, "john@doe.com");
                 $this->assertEquals( $ticket->requester_id, $requester->id);
             });
-            $this->assertEquals ( $ticket->title, "App <\script>is not working</\script>");
-            $this->assertEquals ( $ticket->body, "I can't log in into the application<\script>alert(1)</\script>");
+            $this->assertEquals ( $ticket->title, "App is not working >>>");
+            $this->assertEquals ( $ticket->body, "I can't log in into the applicationalert(1)");
             $this->assertTrue   ( $ticket->tags->pluck('name')->contains("xef") );
             $this->assertEquals( Ticket::STATUS_NEW, $ticket->status);
 
@@ -222,7 +222,7 @@ class SimpleTicketTest extends TestCase
         $response->assertJson   (["data" => ["id" => 2]]);
 
         $this->assertCount  (2, $ticket->comments);
-        $this->assertEquals ($ticket->comments[1]->body, "<\script> this is a comment </\script>");
+        $this->assertEquals ($ticket->comments[1]->body, " this is a comment ");
 
         //TODO: assert notifications
     }

--- a/tests/Feature/Api/SimpleTicketTest.php
+++ b/tests/Feature/Api/SimpleTicketTest.php
@@ -82,6 +82,51 @@ class SimpleTicketTest extends TestCase
     }
 
     /** @test */
+    public function can_create_a_ticket_with_js_injection(){
+        Notification::fake();
+        $admin      = factory(Admin::class)->create();
+        $nonAdmin   = factory(User::class)->create(["admin" => 0]);
+
+        $response = $this->post('api/tickets',[
+            "requester" => [
+                "name"  => "johndoe",
+                "email" => "john@doe.com"
+            ],
+            "title"         => "App <script>is not working</script>",
+            "body"          => "I can't log in into the application<script>alert(1)</script>",
+            "tags"          => ["xef"]
+        ],["token" => 'the-api-token']);
+
+        $response->assertStatus( Response::HTTP_CREATED );
+        $response->assertJson(["data" => ["id" => 1]]);
+
+        tap( Ticket::first(), function($ticket) use($admin) {
+            tap( Requester::first(), function($requester) use ($ticket){
+                $this->assertEquals($requester->name, "johndoe");
+                $this->assertEquals($requester->email, "john@doe.com");
+                $this->assertEquals( $ticket->requester_id, $requester->id);
+            });
+            $this->assertEquals ( $ticket->title, "App <\script>is not working</\script>");
+            $this->assertEquals ( $ticket->body, "I can't log in into the application<\script>alert(1)</\script>");
+            $this->assertTrue   ( $ticket->tags->pluck('name')->contains("xef") );
+            $this->assertEquals( Ticket::STATUS_NEW, $ticket->status);
+
+            Notification::assertSentTo(
+                [$admin],
+                TicketCreated::class,
+                function ($notification, $channels) use ($ticket) {
+                    return $notification->ticket->id === $ticket->id;
+                }
+            );
+        });
+
+
+        Notification::assertNotSentTo(
+            [$nonAdmin], TicketCreated::class
+        );
+    }
+
+    /** @test */
     public function requester_is_required(){
         $response = $this->post('api/tickets',$this->validParams([
             "requester" => "",
@@ -159,6 +204,25 @@ class SimpleTicketTest extends TestCase
 
         $this->assertCount  (2, $ticket->comments);
         $this->assertEquals ($ticket->comments[1]->body, "this is a comment");
+
+        //TODO: assert notifications
+    }
+
+    /** @test */
+    public function requester_can_comment_the_ticket_with_js_injection(){
+        Notification::fake();
+        $ticket = factory(Ticket::class)->create();
+        $ticket->comments()->create(["body" => "first comment", "new_status" => 1]);
+
+        $response = $this->post("api/tickets/{$ticket->id}/comments", [
+            "body" => "<script> this is a comment </script>"
+        ],["token" => 'the-api-token']);
+
+        $response->assertStatus ( Response::HTTP_CREATED );
+        $response->assertJson   (["data" => ["id" => 2]]);
+
+        $this->assertCount  (2, $ticket->comments);
+        $this->assertEquals ($ticket->comments[1]->body, "<\script> this is a comment </\script>");
 
         //TODO: assert notifications
     }


### PR DESCRIPTION
Linear: https://linear.app/revo/issue/REV-2324/tickets-from-retail-xef-to-handesk-prevent-javascript-injection-when

Example: <script>alert(1)</script> => result: <\script>alert(1)</\script>.

Tests made:
 - can_create_a_ticket_with_js_injection()
 - requester_can_comment_the_ticket_with_js_injection()