### PR TITLE
Failed to parse dotenv file due to an invalid name.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ MAIL_FETCH_USERNAME=hello@handesk.com
 MAIL_FETCH_PASSWORD=secret-password
 MAIL_FETCH_OPTIONS=/pop3
 MAIL_FETCH_USE_SSL=true
-// for options check https://secure.php.net/manual/de/function.imap-open.php
+# for options check https://secure.php.net/manual/de/function.imap-open.php
 
 MAIL_SSLOPTIONS_ALLOW_SELF_SIGNED=false
 MAIL_SSLOPTIONS_VERIFY_PEER=true
@@ -46,7 +46,7 @@ PUSHER_APP_ID=
 PUSHER_APP_KEY=
 PUSHER_APP_SECRET=
 
-//Leave ISSUES_DRIVER empty to not use any
+# Leave ISSUES_DRIVER empty to not use any
 ISSUES_DRIVER=bitbucket
 BITBUCKET_USER=bitbucket-user-if-using-basic-auth
 BITBUCKET_PASSWORD=bitbucket-password-if-using-basic-auth


### PR DESCRIPTION
Failed to parse dotenv file due to an invalid name. Failed at [// for options check https://secure.php.net/manual/de/function.imap-open.php].

#766 